### PR TITLE
Add sets for pending and fulfilled request ids (for tracking of missed requests by agent) and upgrade smart contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library is designed with modularity and simplicity in mind, allowing develo
 | BlocklockSender Proxy | 0xfF66908E1d7d23ff62791505b2eC120128918F44   | Filecoin Testnet |
 | BlocklockSender Implementation | 0x82aDC09b6c767583a3CfEA39FC400e4a698D53D0   | Filecoin Testnet |
 | DecryptionSender Proxy | 0x9297Bb1d423ef7386C8b2e6B7BdE377977FBedd3   | Filecoin Testnet |
-| DecryptionSender Implementation | 0x440ccac6429a5bA45bB814A5253e57832499e8a0   | Filecoin Testnet |
+| DecryptionSender Implementation | 0x7ff25f07b2CE22E274458b00E5Df0ea05918Dbf9   | Filecoin Testnet |
 | SignatureSchemeAddressProvider | 0xD2b5084E68230D609AEaAe5E4cF7df9ebDd6375A   | Filecoin Testnet |
 | BlocklockSignatureScheme | 0x62C9CF8Ff30177d8479eDaB017f38017bEbf10C2   | Filecoin Testnet |
 | MockBlocklockReceiver | 0x6f637EcB3Eaf8bEd0fc597Dc54F477a33BBCA72B   | Filecoin Testnet |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This library is designed with modularity and simplicity in mind, allowing develo
 | Contract        | Address | Network          |
 |-----------------|---------|------------------|
 | BlocklockSender Proxy | 0xfF66908E1d7d23ff62791505b2eC120128918F44   | Filecoin Testnet |
-| BlocklockSender Implementation | 0x2c42CAe1B8b7F03A503480B6908ff204fE48C8F5   | Filecoin Testnet |
+| BlocklockSender Implementation | 0x82aDC09b6c767583a3CfEA39FC400e4a698D53D0   | Filecoin Testnet |
 | DecryptionSender Proxy | 0x9297Bb1d423ef7386C8b2e6B7BdE377977FBedd3   | Filecoin Testnet |
 | DecryptionSender Implementation | 0x440ccac6429a5bA45bB814A5253e57832499e8a0   | Filecoin Testnet |
 | SignatureSchemeAddressProvider | 0xD2b5084E68230D609AEaAe5E4cF7df9ebDd6375A   | Filecoin Testnet |

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This library is designed with modularity and simplicity in mind, allowing develo
 | Contract        | Address | Network          |
 |-----------------|---------|------------------|
 | BlocklockSender Proxy | 0xfF66908E1d7d23ff62791505b2eC120128918F44   | Filecoin Testnet |
-| BlocklockSender Implementation | 0x82aDC09b6c767583a3CfEA39FC400e4a698D53D0   | Filecoin Testnet |
+| BlocklockSender Implementation | 0x084ca85f6240F0e27384dEb96cC7C2C35eEdf7D6   | Filecoin Testnet |
 | DecryptionSender Proxy | 0x9297Bb1d423ef7386C8b2e6B7BdE377977FBedd3   | Filecoin Testnet |
-| DecryptionSender Implementation | 0x7ff25f07b2CE22E274458b00E5Df0ea05918Dbf9   | Filecoin Testnet |
+| DecryptionSender Implementation | 0x4B1d648EaF947a3C95Fb3D277b086DF7C11FdBbC   | Filecoin Testnet |
 | SignatureSchemeAddressProvider | 0xD2b5084E68230D609AEaAe5E4cF7df9ebDd6375A   | Filecoin Testnet |
 | BlocklockSignatureScheme | 0x62C9CF8Ff30177d8479eDaB017f38017bEbf10C2   | Filecoin Testnet |
 | MockBlocklockReceiver | 0x6f637EcB3Eaf8bEd0fc597Dc54F477a33BBCA72B   | Filecoin Testnet |

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This library is designed with modularity and simplicity in mind, allowing develo
 | Contract        | Address | Network          |
 |-----------------|---------|------------------|
 | BlocklockSender Proxy | 0xfF66908E1d7d23ff62791505b2eC120128918F44   | Filecoin Testnet |
-| BlocklockSender Implementation | 0x084ca85f6240F0e27384dEb96cC7C2C35eEdf7D6   | Filecoin Testnet |
+| BlocklockSender Implementation | 0xb8a5e04A88412190eFF892fcA51123028BCdA12F   | Filecoin Testnet |
 | DecryptionSender Proxy | 0x9297Bb1d423ef7386C8b2e6B7BdE377977FBedd3   | Filecoin Testnet |
-| DecryptionSender Implementation | 0x4B1d648EaF947a3C95Fb3D277b086DF7C11FdBbC   | Filecoin Testnet |
+| DecryptionSender Implementation | 0xd8f2dDbBc1a0c948A9F2560a7524C945D765DEaF   | Filecoin Testnet |
 | SignatureSchemeAddressProvider | 0xD2b5084E68230D609AEaAe5E4cF7df9ebDd6375A   | Filecoin Testnet |
 | BlocklockSignatureScheme | 0x62C9CF8Ff30177d8479eDaB017f38017bEbf10C2   | Filecoin Testnet |
 | MockBlocklockReceiver | 0x6f637EcB3Eaf8bEd0fc597Dc54F477a33BBCA72B   | Filecoin Testnet |

--- a/scripts/mocks/create-timelock-request.ts
+++ b/scripts/mocks/create-timelock-request.ts
@@ -14,18 +14,10 @@ import { keccak_256 } from "@noble/hashes/sha3";
 // yarn ts-node scripts/mocks/create-timelock-request.ts 
 
 const RPC_URL = process.env.CALIBRATIONNET_RPC_URL;
-// const walletAddr = "0x5d84b82b750B996BFC1FA7985D90Ae8Fbe773364"
-const walletAddr = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+const walletAddr = "0x5d84b82b750B996BFC1FA7985D90Ae8Fbe773364"
 const blocklockSenderAddr = "0xfF66908E1d7d23ff62791505b2eC120128918F44"
 const decryptionSenderAddr = "0x9297Bb1d423ef7386C8b2e6B7BdE377977FBedd3";
 const mockBlocklockReceiverAddr = "0x6f637EcB3Eaf8bEd0fc597Dc54F477a33BBCA72B";
-
-// const RPC_URL = "http://127.0.0.1:8545"
-// const walletAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-
-// const blocklockSenderAddr = "0xC6bA8C3233eCF65B761049ef63466945c362EdD2";
-// const decryptionSenderAddr = "0xbCF26943C0197d2eE0E5D05c716Be60cc2761508";
-// const mockBlocklockReceiverAddr = "0x0b48aF34f4c854F5ae1A3D587da471FeA45bAD52";
 
 const BLOCKLOCK_IBE_OPTS: IbeOpts = {
     hash: keccak_256,
@@ -122,7 +114,7 @@ async function main() {
         const mockBlocklockReceiver = MockBlocklockReceiver__factory.connect(mockBlocklockReceiverAddr, signer);
 
         // create a timelock request from mockBlocklockReceiver contract and check it is fulfilled by blocklock agent
-        const blockHeight = BigInt(await provider.getBlockNumber() + 5);
+        const blockHeight = BigInt(await provider.getBlockNumber() + 6);
         const msg = ethers.parseEther("4");
         const abiCoder = AbiCoder.defaultAbiCoder();
         const msgBytes = abiCoder.encode(["uint256"], [msg]);

--- a/scripts/mocks/create-timelock-request.ts
+++ b/scripts/mocks/create-timelock-request.ts
@@ -14,8 +14,8 @@ import { keccak_256 } from "@noble/hashes/sha3";
 // yarn ts-node scripts/mocks/create-timelock-request.ts 
 
 const RPC_URL = process.env.CALIBRATIONNET_RPC_URL;
-const walletAddr = "0x5d84b82b750B996BFC1FA7985D90Ae8Fbe773364"
-// const walletAddr = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+// const walletAddr = "0x5d84b82b750B996BFC1FA7985D90Ae8Fbe773364"
+const walletAddr = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
 const blocklockSenderAddr = "0xfF66908E1d7d23ff62791505b2eC120128918F44"
 const decryptionSenderAddr = "0x9297Bb1d423ef7386C8b2e6B7BdE377977FBedd3";
 const mockBlocklockReceiverAddr = "0x6f637EcB3Eaf8bEd0fc597Dc54F477a33BBCA72B";

--- a/src/blocklock/BlocklockSender.sol
+++ b/src/blocklock/BlocklockSender.sol
@@ -34,8 +34,7 @@ contract BlocklockSender is
     bytes public constant DST_H3 = "BLOCKLOCK_BN254_XMD:KECCAK-256_H3_";
     bytes public constant DST_H4 = "BLOCKLOCK_BN254_XMD:KECCAK-256_H4_";
 
-    // Mapping from decryption requestID to blocklock status
-    mapping(uint256 => TypesLib.BlocklockRequest) public blocklockRequests;
+    // Mapping from decryption requestID to conditional decryption request
     mapping(uint256 => TypesLib.BlocklockRequest) public blocklockRequestsWithDecryptionKey;
 
     event BlocklockRequested(
@@ -183,6 +182,7 @@ contract BlocklockSender is
      */
     function isInFlight(uint256 requestID) external view returns (bool) {
         uint256 signatureRequestID = blocklockRequestsWithDecryptionKey[requestID].decryptionRequestID;
+        
         if (signatureRequestID == 0) {
             return false;
         }

--- a/src/blocklock/BlocklockSender.sol
+++ b/src/blocklock/BlocklockSender.sol
@@ -182,7 +182,7 @@ contract BlocklockSender is
      */
     function isInFlight(uint256 requestID) external view returns (bool) {
         uint256 signatureRequestID = blocklockRequestsWithDecryptionKey[requestID].decryptionRequestID;
-        
+
         if (signatureRequestID == 0) {
             return false;
         }

--- a/src/blocklock/BlocklockSender.sol
+++ b/src/blocklock/BlocklockSender.sol
@@ -183,7 +183,9 @@ contract BlocklockSender is
      */
     function isInFlight(uint256 requestID) external view returns (bool) {
         uint256 signatureRequestID = blocklockRequestsWithDecryptionKey[requestID].decryptionRequestID;
-        require(signatureRequestID > 0, "blocklock request not found");
+        if (signatureRequestID == 0) {
+            return false;
+        }
 
         return decryptionSender.isInFlight(signatureRequestID);
     }

--- a/src/decryption-requests/DecryptionSender.sol
+++ b/src/decryption-requests/DecryptionSender.sol
@@ -42,7 +42,7 @@ contract DecryptionSender is
 
     uint256 public lastRequestID = 0;
     BLS.PointG2 private publicKey = BLS.PointG2({x: [uint256(0), uint256(0)], y: [uint256(0), uint256(0)]});
-    
+
     // Mapping from decryption requestID to conditional decryption request
     mapping(uint256 => TypesLib.DecryptionRequest) public requests;
 
@@ -220,10 +220,6 @@ contract DecryptionSender is
 
     function getAllUnfulfilledRequestIds() external view returns (uint256[] memory) {
         return unfulfilledRequestIds.values();
-    }
-
-    function getCountOfFulfilledRequestIds() external view returns (uint256) {
-        return fulfilledRequestIds.length();
     }
 
     function getCountOfUnfulfilledRequestIds() external view returns (uint256) {

--- a/src/decryption-requests/DecryptionSender.sol
+++ b/src/decryption-requests/DecryptionSender.sol
@@ -161,7 +161,7 @@ contract DecryptionSender is
             revert DecryptionReceiverCallbackFailed(requestID);
         } else {
             emit DecryptionReceiverCallbackSuccess(requestID, decryptionKey, signature);
-            delete requestsInFlight[requestID];
+            requestsInFlight[requestID].decryptionKey = decryptionKey;
         }
     }
 

--- a/src/decryption-requests/DecryptionSender.sol
+++ b/src/decryption-requests/DecryptionSender.sol
@@ -208,7 +208,7 @@ contract DecryptionSender is
     }
 
     /**
-     * @dev See {IDecryptionSender-getRequestInFlight}.
+     * @dev See {IDecryptionSender-getRequest}.
      */
     function getRequest(uint256 requestID) external view returns (TypesLib.DecryptionRequest memory) {
         return requests[requestID];

--- a/src/decryption-requests/DecryptionSender.sol
+++ b/src/decryption-requests/DecryptionSender.sol
@@ -204,7 +204,7 @@ contract DecryptionSender is
      * @dev See {IDecryptionSender-isInFlight}.
      */
     function isInFlight(uint256 requestID) public view returns (bool) {
-        return !requests[requestID].isFulfilled;
+        return unfulfilledRequestIds.contains(requestID);
     }
 
     /**

--- a/src/decryption-requests/DecryptionSender.sol
+++ b/src/decryption-requests/DecryptionSender.sol
@@ -42,8 +42,8 @@ contract DecryptionSender is
 
     uint256 public lastRequestID = 0;
     BLS.PointG2 private publicKey = BLS.PointG2({x: [uint256(0), uint256(0)], y: [uint256(0), uint256(0)]});
-    mapping(uint256 => TypesLib.DecryptionRequest) public requestsInFlight;
     
+    // Mapping from decryption requestID to conditional decryption request
     mapping(uint256 => TypesLib.DecryptionRequest) public requests;
 
     ISignatureSchemeAddressProvider public signatureSchemeAddressProvider;
@@ -125,7 +125,7 @@ contract DecryptionSender is
         address schemeContractAddress = signatureSchemeAddressProvider.getSignatureSchemeAddress(schemeID);
         require(schemeContractAddress > address(0), "invalid signature scheme");
 
-        requestsInFlight[lastRequestID] = TypesLib.DecryptionRequest({
+        requests[lastRequestID] = TypesLib.DecryptionRequest({
             schemeID: schemeID,
             ciphertext: ciphertext,
             condition: condition,
@@ -149,7 +149,7 @@ contract DecryptionSender is
         onlyOwner
     {
         require(isInFlight(requestID), "No request with specified requestID");
-        TypesLib.DecryptionRequest memory request = requestsInFlight[requestID];
+        TypesLib.DecryptionRequest memory request = requests[requestID];
 
         string memory schemeID = request.schemeID;
         address schemeContractAddress = signatureSchemeAddressProvider.getSignatureSchemeAddress(schemeID);
@@ -204,7 +204,7 @@ contract DecryptionSender is
      * @dev See {IDecryptionSender-isInFlight}.
      */
     function isInFlight(uint256 requestID) public view returns (bool) {
-        return requestsInFlight[requestID].isFulfilled;
+        return !requests[requestID].isFulfilled;
     }
 
     /**

--- a/src/interfaces/IDecryptionSender.sol
+++ b/src/interfaces/IDecryptionSender.sol
@@ -66,13 +66,29 @@ interface IDecryptionSender {
      * @return Bytes string representing the public key points on the elliptic curve.
      */
     function getPublicKeyBytes() external view returns (bytes memory);
-
+    
+    /**
+     * @notice Returns all the fulfilled request ids.
+     * @return A uint array representing a set containing all fulfilled request ids.
+     */
     function getAllFulfilledRequestIds() external view returns (uint256[] memory);
 
+    /**
+     * @notice Returns all the request ids that are yet to be fulfilled.
+     * @return A uint array representing a set containing all request ids that are yet to be fulfilled.
+     */
     function getAllUnfulfilledRequestIds() external view returns (uint256[] memory);
 
+    /**
+     * @notice Returns count of all the request ids that are fulfilled.
+     * @return A uint representing a count of all request ids that are fulfilled.
+     */
     function getCountOfFulfilledRequestIds() external view returns (uint256);
 
+    /**
+     * @notice Returns count of all the request ids that are yet to be fulfilled.
+     * @return A uint representing a count of all request ids that are yet to be fulfilled.
+     */
     function getCountOfUnfulfilledRequestIds() external view returns (uint256);
 
     /**

--- a/src/interfaces/IDecryptionSender.sol
+++ b/src/interfaces/IDecryptionSender.sol
@@ -66,7 +66,7 @@ interface IDecryptionSender {
      * @return Bytes string representing the public key points on the elliptic curve.
      */
     function getPublicKeyBytes() external view returns (bytes memory);
-    
+
     /**
      * @notice Returns all the fulfilled request ids.
      * @return A uint array representing a set containing all fulfilled request ids.
@@ -78,12 +78,6 @@ interface IDecryptionSender {
      * @return A uint array representing a set containing all request ids that are yet to be fulfilled.
      */
     function getAllUnfulfilledRequestIds() external view returns (uint256[] memory);
-
-    /**
-     * @notice Returns count of all the request ids that are fulfilled.
-     * @return A uint representing a count of all request ids that are fulfilled.
-     */
-    function getCountOfFulfilledRequestIds() external view returns (uint256);
 
     /**
      * @notice Returns count of all the request ids that are yet to be fulfilled.

--- a/src/interfaces/IDecryptionSender.sol
+++ b/src/interfaces/IDecryptionSender.sol
@@ -44,7 +44,7 @@ interface IDecryptionSender {
      * @param requestId The ID of the request to retrieve.
      * @return The Request struct corresponding to the given requestId.
      */
-    function getRequestInFlight(uint256 requestId) external view returns (TypesLib.DecryptionRequest memory);
+    function getRequest(uint256 requestId) external view returns (TypesLib.DecryptionRequest memory);
 
     /**
      * @notice Verifies whether a specific request is in flight or not.
@@ -66,6 +66,14 @@ interface IDecryptionSender {
      * @return Bytes string representing the public key points on the elliptic curve.
      */
     function getPublicKeyBytes() external view returns (bytes memory);
+
+    function getAllFulfilledRequestIds() external view returns (uint256[] memory);
+
+    function getAllUnfulfilledRequestIds() external view returns (uint256[] memory);
+
+    function getCountOfFulfilledRequestIds() external view returns (uint256);
+
+    function getCountOfUnfulfilledRequestIds() external view returns (uint256);
 
     /**
      * @dev Returns the version number of the upgradeable contract.

--- a/src/libraries/TypesLib.sol
+++ b/src/libraries/TypesLib.sol
@@ -37,5 +37,6 @@ library TypesLib {
         bytes decryptionKey;
         bytes signature;
         address callback;
+        bool isFulfilled;
     }
 }

--- a/test/hardhat/Blocklock.spec.ts
+++ b/test/hardhat/Blocklock.spec.ts
@@ -418,12 +418,10 @@ describe("BlocklockSender", function () {
 
   it("enumerable set can track multiple requests", async function () {
     let numberOfPendingRequests = await decryptionSender.getCountOfUnfulfilledRequestIds();
-    let numberOfFulfilledRequests = await decryptionSender.getCountOfFulfilledRequestIds();
     let pendingRequestIds = await decryptionSender.getAllUnfulfilledRequestIds();
     let nonPendingRequestIds = await decryptionSender.getAllFulfilledRequestIds();
 
     expect(numberOfPendingRequests).to.be.equal(0);
-    expect(numberOfFulfilledRequests).to.be.equal(0);
     expect(pendingRequestIds.length).to.be.equal(0);
     expect(nonPendingRequestIds.length).to.be.equal(0);
 
@@ -453,12 +451,10 @@ describe("BlocklockSender", function () {
     }
 
     numberOfPendingRequests = await decryptionSender.getCountOfUnfulfilledRequestIds();
-    numberOfFulfilledRequests = await decryptionSender.getCountOfFulfilledRequestIds();
     pendingRequestIds = await decryptionSender.getAllUnfulfilledRequestIds();
     nonPendingRequestIds = await decryptionSender.getAllFulfilledRequestIds();
 
     expect(numberOfPendingRequests).to.be.equal(2);
-    expect(numberOfFulfilledRequests).to.be.equal(0);
     expect(pendingRequestIds.length).to.be.equal(2);
     expect(nonPendingRequestIds.length).to.be.equal(0);
     expect(pendingRequestIds[0]).to.be.equal(1);
@@ -468,15 +464,13 @@ describe("BlocklockSender", function () {
 
   it("can request blocklock decryption from user contract for string and receive decryption key callback", async function () {
     let numberOfPendingRequests = await decryptionSender.getCountOfUnfulfilledRequestIds();
-    let numberOfFulfilledRequests = await decryptionSender.getCountOfFulfilledRequestIds();
     let pendingRequestIds = await decryptionSender.getAllUnfulfilledRequestIds();
     let nonPendingRequestIds = await decryptionSender.getAllFulfilledRequestIds();
 
     expect(numberOfPendingRequests).to.be.equal(0);
-    expect(numberOfFulfilledRequests).to.be.equal(0);
     expect(pendingRequestIds.length).to.be.equal(0);
     expect(nonPendingRequestIds.length).to.be.equal(0);
-    
+
     let blockHeight = await ethers.provider.getBlockNumber();
 
     const msg = "mainnet launch soon";
@@ -502,15 +496,13 @@ describe("BlocklockSender", function () {
     );
 
     numberOfPendingRequests = await decryptionSender.getCountOfUnfulfilledRequestIds();
-    numberOfFulfilledRequests = await decryptionSender.getCountOfFulfilledRequestIds();
     pendingRequestIds = await decryptionSender.getAllUnfulfilledRequestIds();
     nonPendingRequestIds = await decryptionSender.getAllFulfilledRequestIds();
 
     expect(numberOfPendingRequests).to.be.equal(1);
-    expect(numberOfFulfilledRequests).to.be.equal(0);
     expect(pendingRequestIds.length).to.be.equal(1);
     expect(nonPendingRequestIds.length).to.be.equal(0);
-    
+
     expect(pendingRequestIds[0]).to.be.equal(1);
 
     console.log("callback and blocklock address", callback, await blocklock.getAddress());
@@ -553,12 +545,10 @@ describe("BlocklockSender", function () {
     );
 
     numberOfPendingRequests = await decryptionSender.getCountOfUnfulfilledRequestIds();
-    numberOfFulfilledRequests = await decryptionSender.getCountOfFulfilledRequestIds();
     pendingRequestIds = await decryptionSender.getAllUnfulfilledRequestIds();
     nonPendingRequestIds = await decryptionSender.getAllFulfilledRequestIds();
 
     expect(numberOfPendingRequests).to.be.equal(0);
-    expect(numberOfFulfilledRequests).to.be.equal(1);
     expect(pendingRequestIds.length).to.be.equal(0);
     expect(nonPendingRequestIds.length).to.be.equal(1);
 


### PR DESCRIPTION
`TypesLib. DecryptionRequest`

1. Added `bool isFulfilled;` in the `DecryptionRequest` struct so that we can use it to track if a request is inFlight and store all requests on-chain with the same struct to avoid deleting them alongside their decryption keys.

`DecryptionSender`
1. Updated the logic for `isInFlight` to use the new `isFulfilled` property of `DecryptionRequest` rather than checking if a request has default zero data (implying it's been deleted or was not created).
```solidity
function isInFlight(uint256 requestID) public view returns (bool) {
     return unfulfilledRequestIds.contains(requestID);
 }
```
2. Changed `getRequestInFlight` to `getRequest` to fetch either a pending or fulfilled request or zero data if the request id does not exist
3.  Added two Enumerable Sets, i.e., `EnumerableSet.UintSet private fulfilledRequestIds;` and `    EnumerableSet.UintSet private unfulfilledRequestIds;` (as well as getter functions shown below) which keep track of all unique pending or fulfilled request IDs so that the agent can fetch this list and fulfil the pending requests by checking their desired decryption `blockHeight` in `BlocklockSender`. 

```solidity
function getAllFulfilledRequestIds() external view returns (uint256[] memory);
function getAllUnfulfilledRequestIds() external view returns (uint256[] memory);
function getCountOfUnfulfilledRequestIds() external view returns (uint256);
```

Note: we could add blockHeight for each request in `DecryptionSender` too so that the agent only calls `DecryptionSender` but it might be duplication. The agent can parse previous events and check for the blockHeight in the event corresponding to each pending request ID but RPC providers will not allow parsing very old blocks. ___Agent could also search all events for specific indexed requestID from the list of pending request ids to avoid filtering or parsing all events.___

`BlocklockSender` 

1. Updated `isInFlight` so that it does not revert if the request ID does not exist. It either returns true or false gracefully :). So that we can call it from the agent or any other client software if needed without the call reverting / throwing an error.
```solidity
function isInFlight(uint256 requestID) external view returns (bool) {
        uint256 signatureRequestID = blocklockRequestsWithDecryptionKey[requestID].decryptionRequestID;
        
        if (signatureRequestID == 0) {
            return false;
        }

        return decryptionSender.isInFlight(signatureRequestID);
    }
```